### PR TITLE
Bug: dir check and dir var in create secrets

### DIFF
--- a/create_database_secrets.sh
+++ b/create_database_secrets.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+DIR="secrets"
+
+if ! [ -d "$DIR"]; then
+	mkdir secrets
+fi
+
 echo -e "\e[36m[INFO] create default secrets at ./secrets\e[0m"
-echo -n "user_password" > secrets/db_password.secret
-echo -n "password" > secrets/db_root_password.secret
-echo -n "user" > secrets/db_user.secret
+echo -n "user_password" > $DIR/db_password.secret
+echo -n "password" > $DIR/db_root_password.secret
+echo -n "user" > $DIR/db_user.secret
 
 echo -e "\e[36m[INFO] make sure to change the content of the secret files. Dont use the default values in production!\e[0m"
 echo -e "\e[36m[INFO] secrets created.\e[0m"


### PR DESCRIPTION
Bug fixed when running the *create_secrets*-bash when no secret folder exists.